### PR TITLE
Add ignore definition for VS Code

### DIFF
--- a/generators/app/templates/ignorefile
+++ b/generators/app/templates/ignorefile
@@ -236,3 +236,10 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json


### PR DESCRIPTION
Updated `.gitignore` in template to ignore stuff from VS Code.
